### PR TITLE
Adding gzip

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,3 +10,4 @@ Thanks for suggestions and brainstorming.
 
 - Megan Galloway
 - Ray Holder
+- Tianhui Michael Li

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 ediblepickle
 =========================
-.. image:: https://travis-ci.org/mpavan/ediblepickle.png?branch=master
-        :target: https://travis-ci.org/mpavan/ediblepickle
+.. image:: https://travis-ci.org/tianhuil/ediblepickle.svg?branch=master
+        :target: https://travis-ci.org/tianhuil/ediblepickle
 
 ediblepickle is an Apache v 2.0 licensed `checkpointing <http://en.wikipedia.org/wiki/Application_checkpointing>`__ utility.
 The simplest use case is to checkpoint an expensive computation that need not be repeated every time the program is

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ executed, as in:
     from ediblepickle import checkpoint
 
     # A checkpointed expensive function
-    @checkpoint(key=string.Template('m{0}_n{1}_${iterations}_$stride.csv'), work_dir='/tmp/intermediate_results', refresh=True)
+    @checkpoint(key=string.Template('m{0}_n{1}_${iterations}_$stride.csv'), work_dir='/tmp/intermediate_results', refresh=True, gzip=True)
     def expensive_computation(m, n, iterations=4, stride=1):
         for i in range(iterations):
             time.sleep(1)
@@ -42,6 +42,7 @@ Features
 - Configurable computation cache storage format (i.e use human friendly keys and data, instead of pickle binary data)
 - Specify refresh to flush the cache and recompute
 - Specify your own serialize/de-serialize (save/load) functions
+- Enable gzip flag to gzip results of default or custom serialization/deserialization routines.
 - Python logging, just define your own logger to activate it
 
 

--- a/checkpoint_tests.py
+++ b/checkpoint_tests.py
@@ -37,7 +37,7 @@ def expensive_function_creates_checkpoint(n, start=0, stride=1):
 @checkpoint(key=Template('n{0}_start${start}_stride${stride}.txt'), pickler=save_ints, unpickler=load_ints,
            refresh=False)
 def expensive_function_loads_checkpoint(n, start=0, stride=1):
-    sleep(5)
+    sleep(SLEEP_TIME)
     return range(start, n, stride)
 
 

--- a/checkpoint_tests.py
+++ b/checkpoint_tests.py
@@ -249,3 +249,47 @@ def test_string_key_checkpoint_creation_refresh_lambda():
 def test_string_key_checkpoint_loading_refresh_lambda():
     result = expensive_function_loads_checkpoint_str_refresh_lambda(100, start=10, stride=2)
     assert (result == range(10, 100, 2))  # Make sure whats loaded is what should be loaded.
+
+
+# SECTION 6: GZIP STRING KEY TESTING
+
+
+# Create a scenario, where the @checkpoint is loaded after creation; use the string filename.
+@checkpoint(key='test_file.txt.gz', gzip=True, refresh=False)
+def expensive_function_loads_checkpoint_gzip(n, start=0, stride=1):
+    sleep(SLEEP_TIME)
+    return range(start, n, stride)
+
+
+# Create a scenario, where the @checkpoint is first created from 'test_file.txt'.
+@checkpoint(key='test_file.txt.gz', gzip=True, refresh=True)
+def expensive_function_creates_checkpoint_gzip(n, start=0, stride=1):
+    sleep(SLEEP_TIME)
+    return range(start, n, stride)
+
+def test_gzip_checkpoint_creation():
+    key = 'test_file.txt'
+    out_file = os.path.join(gettempdir(), key)
+
+    # make sure you delete the file first
+    try:
+        os.remove(out_file)
+        assert (not os.path.exists(out_file))
+    except OSError as e:  # No such file or directory
+        logging.info('File not found or deleted. Good. Starting the test...')  # we are good. ignore the exception.
+
+    # call the function that creates the file
+    result = expensive_function_creates_checkpoint_str(100, start=10, stride=2)
+
+    logging.info(out_file)
+    # make sure the file is created.
+    assert (os.path.exists(out_file))
+
+
+# this test must run much lesser than 5 seconds, although there is a sleep in the loads function
+# cuz we are just loading. Lets time it to 1 second.
+@timed(1)
+def test_gzip_checkpoint_loading():
+    result = expensive_function_loads_checkpoint_str(100, start=10, stride=2)
+    assert (result == range(10, 100, 2))  # Make sure whats loaded is what should be loaded.
+

--- a/ediblepickle.py
+++ b/ediblepickle.py
@@ -99,7 +99,7 @@ def checkpoint(key=0, unpickler=pickle.load, pickler=pickle.dump, work_dir=gette
 
     :param work_dir: The location where the checkpoint files are stored.
 
-    :param do_refresh: If enabled, this will not skip, effectively disabling the
+    :param refresh: If enabled, this will not skip execution, effectively disabling the
     decoration @checkpoint.
 
     REFRESHING: One of the intended ways to use the refresh feature is as follows:

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ CLASSIFIERS = [
 
 settings.update(
     name='ediblepickle',
-    version='1.1.3',
+    version='1.2.0',
     description='Checkpoint',
     long_description=open('README.rst').read(),
     author='Pavan Mallapragada',


### PR DESCRIPTION
Add a `gzip` flag to compress results.  Works for default as well as custom serializers.  `gzip` is disabled by default to make code backward compatible.

Documented and tested.  This bumps the version to 1.2.0.

@mpavan: thoughts?